### PR TITLE
Add more flexible assertions

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,10 @@ config :my_app, MyApp.SmsSender, adapter: Apus.TestAdapter
 
 Now you can test SMS delivery using the `assert_delivered_message` macro.
 
+### Assertions
+
+For full match use the following example:
+
 ```elixir
 defmodule MyApp.RegistrationTest do
   use ExUnit.Case
@@ -122,4 +126,51 @@ defmodule MyApp.RegistrationTest do
 end
 ```
 
-There is also a `refute_delivered_message` macro for testing that a message was not delivered.
+If you only care that any message was delivered, you can use following assertion:
+```elixir
+test "message gets delivered" do
+  new_user = user
+  
+  Users.register(new_user)
+  
+  message = assert_delivered_message()
+  # do something with the delivered message...
+end
+```
+
+Lastly anonymous function matcher is also provided for more flexible assertions:
+```elixir
+test "some delivered message attrs match" do
+  new_user = user
+  
+  Users.register(new_user)
+  
+  assert_delivered_message_matches(fn message ->
+    assert message.to == new_user.phone_number
+    assert message.body =~ "partial match..."
+  end)
+end
+```
+
+### Refute
+
+There is also a `refute_delivered_message/1` macro for testing that a specific message was not delivered.
+```elixir
+  test "specific message doesn't get delivered" do
+    # Do something...
+
+    # assert that following message wasn't sent out
+    message = %Apus.Message(to: 123, body: "message")
+    refute_delivered_message(message)
+  end
+```
+
+Similarly you can also use `refute_delivered_message/0` to ensure no messages were delivered.
+```elixir
+  test "no messages delivered" do  
+    # Do something....
+
+    # assert no messages were sent out
+    refute_delivered_message()
+  end
+```

--- a/lib/apus/test.ex
+++ b/lib/apus/test.ex
@@ -4,6 +4,77 @@ defmodule Apus.Test do
 
   import ExUnit.Assertions
 
+  @doc """
+  Asserts any message was delivered.
+
+  ## Example
+
+      iex> import Apus.Test
+      iex> alias Apus.Message
+
+      iex> message = %Message{to: 1234, body: "message body"}
+      iex> Apus.TestAdapter.deliver(message, nil)
+
+      iex> # Assert any message was sent
+      iex> assert_delivered_message()
+      %Apus.Message{body: "message body", from: nil, to: 1234}
+  """
+  def assert_delivered_message() do
+    assert_receive {:delivered_message, message},
+                   100,
+                   Apus.Test.flunk_with_message_list("<<any message>>")
+
+    message
+  end
+
+  @spec assert_delivered_message_matches((any -> any)) :: any
+  @doc ~S"""
+  Custom function matcher asserion logic.
+
+  Allows for more flexible message matching
+
+  ## Examples
+
+      iex> import ExUnit.Assertions
+      iex> import Apus.Test
+      iex> alias Apus.Message
+
+      iex> message = %Message{to: 1234, body: "message body with an unknown number 123"}
+      iex> Apus.TestAdapter.deliver(message, nil)
+
+      iex> # custom assertion with a matcher function
+      iex> assert_delivered_message_matches(fn msg ->
+      ...>   assert msg.to == 1234
+      ...>   assert msg.body =~ "unknown"
+      ...> end)
+      %Apus.Message{body: "message body with an unknown number 123", from: nil, to: 1234}
+  """
+  def assert_delivered_message_matches(fun) when is_function(fun, 1) do
+    assert_receive {:delivered_message, message}
+
+    # Run custom function matcher on received message
+    assert(fun.(message))
+
+    message
+  end
+
+  @doc ~S"""
+  Refutes that *any message* was delivered.
+
+  ## Examples
+
+      iex> refute_delivered_message()
+
+  """
+  def refute_delivered_message() do
+    refute_receive {:delivered_message, message},
+                   100,
+                   Apus.Test.flunk_with_unexpected_message(message)
+  end
+
+  @doc """
+  Asserts that a *specific message* was delivered
+  """
   defmacro assert_delivered_message(message, timeout \\ 100) do
     quote do
       import ExUnit.Assertions
@@ -15,6 +86,9 @@ defmodule Apus.Test do
     end
   end
 
+  @doc """
+  Refutes that a *specific message* was delivered
+  """
   defmacro refute_delivered_message(message, timeout \\ 100) do
     quote do
       import ExUnit.Assertions


### PR DESCRIPTION
I found current assertions to be too limiting and needed some more flexibility with partial matching and more flexible assertions in general. I Added the following functions to `Apus.Test` module to achieve that:

`assert_delivered_message/0` - checks if any message was delivered
`assert_delivered_message_matches/1` - allows custom function matching similar to what Swoosh provides with anonymous function test assertions
`refute_delivered_message/0` - refutes that any message was delivered

Docs and readme were updated to reflect the changes above, plus added some additional assertion examples.