### PR TITLE
Switch to `import Config`

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,6 +1,6 @@
 # This file is responsible for configuring your application
 # and its dependencies with the aid of the Mix.Config module.
-use Mix.Config
+import Config
 
 # This configuration is loaded before any dependency and is restricted
 # to this project. If another project depends on this project, this

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,1 +1,1 @@
-use Mix.Config
+import Config

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -1,1 +1,1 @@
-use Mix.Config
+import Config

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,3 +1,3 @@
-use Mix.Config
+import Config
 
 config :logger, level: :warn


### PR DESCRIPTION
Prevents these warnings on startup during local development:

```elixir
warning: use Mix.Config is deprecated. Use the Config module instead
  config/config.exs:3

warning: use Mix.Config is deprecated. Use the Config module instead
  config/dev.exs:1
```