### PR TITLE
Adapter: consistent returns

### DIFF
--- a/lib/apus/adapter.ex
+++ b/lib/apus/adapter.ex
@@ -1,7 +1,12 @@
 defmodule Apus.Adapter do
   @moduledoc """
+  An adapter provides a way to communicate with a third-party SMS service
+  using a consistent API.
   """
 
-  @callback deliver(%Apus.Message{}, %{}) :: any
-  @callback handle_config(map) :: map
+  @doc "Send the SMS message."
+  @callback deliver(%Apus.Message{}, config :: map) :: {:ok, Apus.Message.t()} | {:error, any}
+
+  @doc "Initialize adapter configuration."
+  @callback handle_config(config :: map) :: config :: map
 end

--- a/lib/apus/adapters/local_adapter.ex
+++ b/lib/apus/adapters/local_adapter.ex
@@ -1,5 +1,7 @@
 defmodule Apus.LocalAdapter do
   @moduledoc """
+  Deliver messages to a local inbox, available to view if
+  `Apus.SentMessagesViewerPlug` is installed in your router.
   """
 
   @behaviour Apus.Adapter
@@ -7,7 +9,10 @@ defmodule Apus.LocalAdapter do
   alias Apus.SentMessages
 
   def deliver(message, _config) do
-    SentMessages.push(message)
+    case SentMessages.push(message) do
+      :ok -> {:ok, message}
+      error -> {:error, error}
+    end
   end
 
   def handle_config(config), do: config

--- a/lib/apus/adapters/test_adapter.ex
+++ b/lib/apus/adapters/test_adapter.ex
@@ -1,5 +1,6 @@
 defmodule Apus.TestAdapter do
   @moduledoc """
+  Adapter for use with automated testing.
   """
 
   @behaviour Apus.Adapter
@@ -15,7 +16,10 @@ defmodule Apus.TestAdapter do
   end
 
   def deliver(message, _config) do
-    send(self(), {:delivered_message, message})
+    case send(self(), {:delivered_message, message}) do
+      {:delivered_message, _} -> {:ok, message}
+      error -> {:error, error}
+    end
   end
 
   def handle_config(config) do

--- a/lib/apus/sent_messages.ex
+++ b/lib/apus/sent_messages.ex
@@ -13,7 +13,5 @@ defmodule Apus.SentMessages do
     Agent.update(__MODULE__, fn messages ->
       [message | messages]
     end)
-
-    message
   end
 end

--- a/test/lib/apus/adapters/local_adapter_test.exs
+++ b/test/lib/apus/adapters/local_adapter_test.exs
@@ -9,7 +9,7 @@ defmodule Apus.LocalAdapterTest do
     test "deliver/2 should deliver a message" do
       message = Message.new(from: "+15551234567", to: "+15557654321", body: "Hello there")
 
-      LocalAdapter.deliver(message, %{})
+      {:ok, %Apus.Message{}} = LocalAdapter.deliver(message, %{})
 
       assert SentMessages.all() == [message]
     end

--- a/test/lib/apus/adapters/plivo_adapter_test.exs
+++ b/test/lib/apus/adapters/plivo_adapter_test.exs
@@ -15,7 +15,7 @@ defmodule Apus.PlivoAdapterTest do
       message = Message.new(from: "+15551234567", to: "+15557654321", body: "Hello there")
 
       use_cassette "plivo_sms_from_success", match_requests_on: [:request_body] do
-        {:ok, pl_message} = PlivoAdapter.deliver(message, config)
+        {:ok, %Apus.Message{} = pl_message} = PlivoAdapter.deliver(message, config)
 
         assert pl_message.from == "+15551234567"
         assert pl_message.to == "+15557654321"

--- a/test/lib/apus/adapters/test_adapter_test.exs
+++ b/test/lib/apus/adapters/test_adapter_test.exs
@@ -8,7 +8,7 @@ defmodule Apus.TestAdapterTest do
     test "deliver/2 should deliver a message" do
       message = Message.new(from: "+15551234567", to: "+15557654321", body: "Hello there")
 
-      TestAdapter.deliver(message, %{})
+      {:ok, %Apus.Message{}} = TestAdapter.deliver(message, %{})
 
       assert_received {:delivered_message, ^message}
     end

--- a/test/lib/apus/adapters/twilio_adapter_test.exs
+++ b/test/lib/apus/adapters/twilio_adapter_test.exs
@@ -15,7 +15,7 @@ defmodule Apus.TwilioAdapterTest do
       message = Message.new(from: "+15551234567", to: "+15557654321", body: "Hello there")
 
       use_cassette "twilio_sms_from_success", match_requests_on: [:request_body] do
-        {:ok, %{} = tw_message} = TwilioAdapter.deliver(message, config)
+        {:ok, %Apus.Message{} = tw_message} = TwilioAdapter.deliver(message, config)
 
         assert tw_message.from == "+15551234567"
         assert tw_message.to == "+15557654321"


### PR DESCRIPTION
Refactors all adapters to return `{:ok, %Apus.Message.t()} | {:error, any()}` tuples.

The `LocalAdapter` and `TestAdapter` in particular returned inconsistent responses.

This does not change the SmsSender API (yet), so it is a non-breaking change to anyone calling `SmsSender.deliver/1` and not calling the adapters directly.

Note I'm maintaining a downstream fork here: https://gitlab.com/soapbox-pub/apus 